### PR TITLE
Issue 8 - Automated testing for `content` and `dev` branches

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,0 +1,36 @@
+name: Pre-Deployment Build Test
+
+on:
+  push:
+    branches:
+      - content
+      - dev
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@8575951200e472d5f2d95c625da0c7bec8217c42
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true 
+          cache-version: 0
+
+      - name: Build with Jekyll
+        run: bundle exec jekyll build
+        env:
+          JEKYLL_ENV: development
+
+      - name: Verify Build Output
+        run: |
+          echo "Contents of the _site directory:"
+          ls -l _site


### PR DESCRIPTION
Added integration testing workflow for content and dev branches
- Added GitHub Actions workflow for integration testing, under integration-test.yml in .github/workflows
- Workflow triggers on pushes to content and dev
- Runs the build process without deployment