### PR TITLE
Add social media links

### DIFF
--- a/_data/social.yml
+++ b/_data/social.yml
@@ -1,0 +1,6 @@
+- title: Email
+  url: mailto:nyjc.computing@nyjc.edu.sg
+  icon: fas fa-envelope
+- title: GitHub
+  url: https://github.com/nyjc-computing
+  icon: fab fa-github

--- a/_data/social.yml
+++ b/_data/social.yml
@@ -1,6 +1,0 @@
-- title: Email
-  url: mailto:nyjc.computing@nyjc.edu.sg
-  icon: fas fa-envelope
-- title: GitHub
-  url: https://github.com/nyjc-computing
-  icon: fab fa-github


### PR DESCRIPTION
Used Monophase's built-in [Social links](https://github.com/zivhub/monophase?tab=readme-ov-file#social-links) feature to add a social links bar below the footer

Closes #2